### PR TITLE
<moolticute-cli/parameters: 1st draft for implemented parameter command>

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -110,3 +110,9 @@ func processDataCmd(subCmd, context, filename string, progressFunc ProgressCb) (
 
 	return
 }
+
+func processParameterCmd(subCmd, parameter string, value string) (err error) {
+	fmt.Println(errorRed(CharAbort), "Not implemented yet")
+
+	return (nil)
+}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ var (
 	optDesc      *string
 	optPrintDesc *bool
 	optFilename  *string
+	optParameter *string
+	optValue     *string
 
 	isTerminal  bool
 	progressBar *progress.ProgressBar
@@ -143,7 +145,35 @@ func main() {
 	})
 
 	app.Command("parameters", "Get/Set device parameters", func(cmd *cli.Cmd) {
-		checkLog()
+		cmd.Command("get", "Retrieve device parameter", func(cmd *cli.Cmd) {
+			optParameter = cmd.StringArg("PARAMETER", "", "Selected device parameter")
+			addDefaultArgs(cmd)
+			cmd.Spec = "PARAMETER [OPTIONS]"
+
+			cmd.Action = func() {
+				checkLog()
+
+				err := processParameterCmd("get", *optParameter, "")
+				if err != nil {
+					exit(err, 1)
+				}
+			}
+		})
+		cmd.Command("set", "Set device parameter", func(cmd *cli.Cmd) {
+			optParameter = cmd.StringArg("PARAMETER", "", "Selected device parameter")
+			optValue = cmd.StringArg("VALUE", "", "Value to set the parameter to")
+			addDefaultArgs(cmd)
+			cmd.Spec = "PARAMETER VALUE [OPTIONS]"
+
+			cmd.Action = func() {
+				checkLog()
+
+				err := processParameterCmd("set", *optParameter, *optValue)
+				if err != nil {
+					exit(err, 1)
+				}
+			}
+		})
 	})
 
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Nothing is done but prevent a segfault, I will try to add functionality later if you would like.

```
$ moolticute-cli parameters
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4021e4]

goroutine 1 [running]:
panic(0x6599c0, 0xc420010100)
        /usr/lib/go/src/runtime/panic.go:500 +0x1a1
main.checkLog()
        /build/moolticute-cli/src/src/github.com/raoulh/moolticute-cli/main.go:58 +0x24
main.main.func3(0xc42000ab00)
        /build/moolticute-cli/src/src/github.com/raoulh/moolticute-cli/main.go:146 +0x14
github.com/jawher/mow%2ecli.(*Cmd).doInit(0xc42000ab00, 0x38f7194f99d, 0xa)
        /build/moolticute-cli/src/src/github.com/jawher/mow.cli/commands.go:252 +0x38b
github.com/jawher/mow%2ecli.(*Cmd).parse(0xc42000a800, 0xc42000c310, 0x1, 0x1, 0xc420049eb8, 0xc420049eb8, 0xc4200158c0, 0xc4200d1501, 0xc4200158c0)
        /build/moolticute-cli/src/src/github.com/jawher/mow.cli/commands.go:452 +0x919
github.com/jawher/mow%2ecli.(*Cli).parse(0xc420049f28, 0xc42000c310, 0x1, 0x1, 0xc420049eb8, 0xc420049eb8, 0xc4200158c0, 0x4, 0x2)
        /build/moolticute-cli/src/src/github.com/jawher/mow.cli/cli.go:73 +0xa9
github.com/jawher/mow%2ecli.(*Cli).Run(0xc420049f28, 0xc42000c300, 0x2, 0x2, 0x19, 0x6c72b8)
        /build/moolticute-cli/src/src/github.com/jawher/mow.cli/cli.go:102 +0x14a
main.main()
        /build/moolticute-cli/src/src/github.com/raoulh/moolticute-cli/main.go:149 +0x2b4

```